### PR TITLE
feat: update docs to use latest coven, installation update, server

### DIFF
--- a/docs/developer-guides/examples/ai/agent.md
+++ b/docs/developer-guides/examples/ai/agent.md
@@ -84,8 +84,8 @@ Using this WIT definition, we can create a WebAssembly component that exports th
 package hayride:agents@0.0.1;
 
 world default {
-    include hayride:wasip2/imports@0.0.59;
-    export hayride:ai/agents@0.0.59;
+    include hayride:wasip2/imports@0.0.60;
+    export hayride:ai/agents@0.0.60;
 }
 ```
 
@@ -98,8 +98,8 @@ In the `wit` directory, create a `deps.toml` file to manage the dependencies for
 This file will specify the dependencies required for your Morph:
 
 ```toml
-wasip2 = "https://github.com/hayride-dev/coven/releases/download/v0.0.59/hayride_wasip2_v0.0.59.tar.gz"
-ai = "https://github.com/hayride-dev/coven/releases/download/v0.0.59/hayride_ai_v0.0.59.tar.gz"
+wasip2 = "https://github.com/hayride-dev/coven/releases/download/v0.0.60/hayride_wasip2_v0.0.60.tar.gz"
+ai = "https://github.com/hayride-dev/coven/releases/download/v0.0.60/hayride_ai_v0.0.60.tar.gz"
 ```
 
 Using `wit-deps`, we can pull in the dependencies for our WIT files.

--- a/docs/developer-guides/examples/hello-world.md
+++ b/docs/developer-guides/examples/hello-world.md
@@ -40,8 +40,8 @@ In the `wit/world.wit` file, define the interface for your Morph. This interface
 package hayride-examples:hello-world@0.0.1;
 
 world hello-world {
-    include hayride:wasip2/imports@0.0.59;
-    include hayride:wasip2/exports@0.0.59;
+    include hayride:wasip2/imports@0.0.60;
+    include hayride:wasip2/exports@0.0.60;
 }
 ```
 
@@ -60,7 +60,7 @@ In the wit directory, create a `deps.toml` file to manage the dependencies for y
 This file will specify the dependencies required for your Morph:
 
 ```toml
-wasip2 = "https://github.com/hayride-dev/coven/releases/download/v0.0.59/hayride_wasip2_v0.0.59.tar.gz"
+wasip2 = "https://github.com/hayride-dev/coven/releases/download/v0.0.60/hayride_wasip2_v0.0.60.tar.gz"
 ```
 
 Using `wit-deps`, we can pull in the dependencies for our WIT files. 

--- a/docs/developer-guides/examples/http/client.md
+++ b/docs/developer-guides/examples/http/client.md
@@ -43,10 +43,10 @@ Additionally we will be using the `hayride:http/client` module to provide the HT
 package hayride-examples:http@0.0.1;
 
 world client {
-    include hayride:wasip2/imports@0.0.59;
-    include hayride:wasip2/exports@0.0.59;
+    include hayride:wasip2/imports@0.0.60;
+    include hayride:wasip2/exports@0.0.60;
  
-    include hayride:http/client@0.0.59;
+    include hayride:http/client@0.0.60;
 }
 ```
 
@@ -57,8 +57,9 @@ In the wit directory, create a `deps.toml` file to manage the dependencies for y
 This file will specify the dependencies required for your Morph:
 
 ```toml
-wasip2 = "https://github.com/hayride-dev/coven/releases/download/v0.0.59/hayride_wasip2_v0.0.59.tar.gz"
-hayride-http = "https://github.com/hayride-dev/coven/releases/download/v0.0.59/hayride_http_v0.0.59.tar.gz"
+http = "https://github.com/WebAssembly/wasi-http/archive/refs/tags/v0.2.0.tar.gz"
+wasip2 = "https://github.com/hayride-dev/coven/releases/download/v0.0.60/hayride_wasip2_v0.0.60.tar.gz"
+hayride-http = "https://github.com/hayride-dev/coven/releases/download/v0.0.60/hayride_http_v0.0.60.tar.gz"
 ```
 
 Using `wit-deps`, we can pull in the dependencies for our WIT files. 

--- a/docs/developer-guides/examples/http/server.md
+++ b/docs/developer-guides/examples/http/server.md
@@ -42,9 +42,9 @@ Additionally we will be using the `hayride:http/server` module to specify that w
 package hayride-examples:http@0.0.1;
 
 world server {
-    include hayride:wasip2/imports@0.0.59;
+    include hayride:wasip2/imports@0.0.60;
  
-    include hayride:http/server@0.0.59;
+    include hayride:http/server@0.0.60;
 }
 ```
 
@@ -55,8 +55,9 @@ In the wit directory, create a `deps.toml` file to manage the dependencies for y
 This file will specify the dependencies required for your Morph:
 
 ```toml
-wasip2 = "https://github.com/hayride-dev/coven/releases/download/v0.0.59/hayride_wasip2_v0.0.59.tar.gz"
-hayride-http = "https://github.com/hayride-dev/coven/releases/download/v0.0.59/hayride_http_v0.0.59.tar.gz"
+http = "https://github.com/WebAssembly/wasi-http/archive/refs/tags/v0.2.0.tar.gz"
+wasip2 = "https://github.com/hayride-dev/coven/releases/download/v0.0.60/hayride_wasip2_v0.0.60.tar.gz"
+hayride-http = "https://github.com/hayride-dev/coven/releases/download/v0.0.60/hayride_http_v0.0.60.tar.gz"
 ```
 
 Using `wit-deps`, we can pull in the dependencies for our WIT files. 

--- a/docs/developer-guides/languages/go.md
+++ b/docs/developer-guides/languages/go.md
@@ -75,13 +75,13 @@ In the `wit/world.wit` file, define the interface for your Morph. This interface
 package hayride:http-morphs@0.0.1;
 
 world http-client {
-    include hayride:wasip2/imports@0.0.59;
-    include hayride:wasip2/exports@0.0.59;
-    include hayride:http/client@0.0.59;
+    include hayride:wasip2/imports@0.0.60;
+    include hayride:wasip2/exports@0.0.60;
+    import wasi:http/outgoing-handler@0.2.0;
 }
 ```
 
-In the above WIT file, we define a world called `http-client` that includes the necessary imports and exports for the Morph. Specifically, we include the `hayride:wasip2/imports` and `hayride:wasip2/exports` modules to provide the necessary WASI functionality, and the `hayride:http/client` module to provide HTTP client capabilities.
+In the above WIT file, we define a world called `http-client` that includes the necessary imports and exports for the Morph. Specifically, we include the `hayride:wasip2/imports` and `hayride:wasip2/exports` modules to provide the necessary WASI functionality, and the `wasi:http/outgoing-handler` module to provide HTTP client capabilities.
 
 When compiling with TinyGo, we will include this WIT file to ensure the Wasm binary is generated with the correct imports and exports. 
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,15 +6,11 @@ sidebar_position: 2
 
 The easiest way to install Hayride is through our installation script.
 
-You can download our installation script, but visiting our [releases repository](https://github.com/hayride-dev/releases/releases), or directly install with the following command:
+You can find the latest binaries and Windows installer by visiting our [releases repository](https://github.com/hayride-dev/releases/releases), or directly install with the following command on Mac or Linux:
 
 ```bash
 curl https://raw.githubusercontent.com/hayride-dev/releases/refs/heads/main/install.sh -sSf | bash
 ```
-
-:::info
-Currently only MacOS x86_64 and ARM targets are supported. Cross platform installations coming soon!
-:::
 
 ## Validating Installation
 

--- a/docs/platform/core/cli.md
+++ b/docs/platform/core/cli.md
@@ -13,20 +13,20 @@ The CLI morph itself is a WebAssembly Component that can be represented through 
 
 ```wit
 world cli {
-    include hayride:wasip2/imports@0.0.59;
+    include hayride:wasip2/imports@0.0.60;
 
     // silo imports
-    import hayride:silo/threads@0.0.59;
-    import hayride:silo/process@0.0.59;
+    import hayride:silo/threads@0.0.60;
+    import hayride:silo/process@0.0.60;
 
     // wasi imports
     import wasi:http/outgoing-handler@0.2.0;
 
     // wac imports
-    import hayride:wac/wac@0.0.59;
+    import hayride:wac/wac@0.0.60;
 
     // exports
-    include hayride:wasip2/exports@0.0.59;
+    include hayride:wasip2/exports@0.0.60;
 }
 ```
 
@@ -42,7 +42,7 @@ Always refer to the git repository, [Coven](https://github.com/hayride-dev/coven
 
 The CLI includes the following `public` imports from the Hayride platform:
 - `wasi:http/outgoing-handler@0.2.0`: A WebAssembly HTTP client that allows the CLI to make HTTP requests to the Hayride platform.
-- `hayride:wac/wac@0.0.59`: WebAssembly Composition import that provides `WAC` functionality for composing WebAssembly components.
+- `hayride:wac/wac@0.0.60`: WebAssembly Composition import that provides `WAC` functionality for composing WebAssembly components.
 
 These imports provide the necessary functionality for the CLI to interact with the Hayride platform, including HTTP client capabilities, WAC (WebAssembly Component) imports, and core configuration management. Each of these imports is defined publicly in our [Coven](https://github.com/hayride-dev/coven) repository, allowing for additional implementations. 
 
@@ -51,7 +51,7 @@ These imports provide the necessary functionality for the CLI to interact with t
 Hayride has `private` or `reserved` imports that are not intended for `public` use. These imports are restricted to the Hayride platform and are used internally by the CLI. 
 
 They include:
-- `hayride:silo/threads@0.0.59` and `hayride:silo/process@0.0.59`: Silo implements basic parallelism and concurrency primitives for the Hayride platform. It provides a way to run Morphs in parallel and manage their execution. This is not intended for public use and is reserved for the Hayride platform. More holistic Async support is being discussed by the WebAssembly community and may replace this in the future.
+- `hayride:silo/threads@0.0.60` and `hayride:silo/process@0.0.60`: Silo implements basic parallelism and concurrency primitives for the Hayride platform. It provides a way to run Morphs in parallel and manage their execution. This is not intended for public use and is reserved for the Hayride platform. More holistic Async support is being discussed by the WebAssembly community and may replace this in the future.
 
 :::info 
 For a complete overview Hayride's WIT definition, please refer to the our [reference documentation](../../reference/interfaces/)

--- a/docs/platform/core/runtime.md
+++ b/docs/platform/core/runtime.md
@@ -40,46 +40,50 @@ The Hayride runtime implements a collection of [WIT](https://github.com/WebAssem
 package hayride:runtime@0.0.1;
 
 world hayride-server {
-    include hayride:wasip2/imports@0.0.59;
+    include hayride:wasip2/imports@0.0.60;
     
     // exports
     export wasi:http/incoming-handler@0.2.0;
-    export hayride:http/config@0.0.59;
+    export hayride:http/config@0.0.60;
 }
 
 world hayride-cli {
-    include hayride:wasip2/imports@0.0.59;
-    include hayride:wasip2/exports@0.0.59;
+    include hayride:wasip2/imports@0.0.60;
+    include hayride:wasip2/exports@0.0.60;
 }
 
 world hayride-ws {
-    export hayride:socket/websocket@0.0.59;
+    export hayride:socket/websocket@0.0.60;
 }
 
 world hayride-ai {
     include wasi:nn/ml@0.2.0-rc-2024-10-28;
 
-    import hayride:ai/tensor-stream@0.0.59;
-    import hayride:ai/inference-stream@0.0.59;
-    import hayride:ai/graph-stream@0.0.59;
+    import hayride:ai/tensor-stream@0.0.60;
+    import hayride:ai/inference-stream@0.0.60;
+    import hayride:ai/graph-stream@0.0.60;
 
-    import hayride:ai/agents@0.0.59;
-    import hayride:ai/model@0.0.59;
-    import hayride:ai/model-repository@0.0.59;
-    import hayride:ai/rag@0.0.59;
+    import hayride:ai/agents@0.0.60;
+    import hayride:ai/model@0.0.60;
+    import hayride:ai/model-repository@0.0.60;
+    import hayride:ai/rag@0.0.60;
+}
+
+world hayride-core {
+    import hayride:core/version@0.0.60;
 }
 
 world hayride-api {
-    import hayride:core/types@0.0.59;
+    import hayride:core/types@0.0.60;
 }
 
 world hayride-silo {
-    import hayride:silo/threads@0.0.59;
-    import hayride:silo/process@0.0.59;
+    import hayride:silo/threads@0.0.60;
+    import hayride:silo/process@0.0.60;
 }
 
 world hayride-wac {
-    import hayride:wac/wac@0.0.59;
+    import hayride:wac/wac@0.0.60;
 }
 ```
 

--- a/docs/platform/core/server.md
+++ b/docs/platform/core/server.md
@@ -15,21 +15,24 @@ The server morph itself is a WebAssembly Component that can be represented throu
 
 ```wit
 world server {
-    include hayride:wasip2/imports@0.0.59;
+    include hayride:wasip2/imports@0.0.60;
+
+    // core imports
+    import hayride:core/version@0.0.60;
 
     // silo imports
-    import hayride:silo/threads@0.0.59;
-    import hayride:silo/process@0.0.59;
+    import hayride:silo/threads@0.0.60;
+    import hayride:silo/process@0.0.60;
 
     // wasi imports
     import wasi:config/store@0.2.0-draft;
 
     // exports
     export wasi:http/incoming-handler@0.2.0;
-    export hayride:http/config@0.0.59;
+    export hayride:http/config@0.0.60;
 }
 ```
-The server world is made up of the wasip2 imports and the `wasi:http/incoming-handler@0.2.0` export for http, but also includes the `hayride:http/config@0.0.59` export, which exposes a config `get` to enable the Hayride to get server configuration such as the address to serve.
+The server world is made up of the wasip2 imports and the `wasi:http/incoming-handler@0.2.0` export for http, but also includes the `hayride:http/config@0.0.60` export, which exposes a config `get` to enable the Hayride to get server configuration such as the address to serve.
 
 The HTTP server implemented is provided by the Hayride runtime. HTTP requests are passed to the server morph, which then routes them to the appropriate handlers.
 
@@ -39,11 +42,12 @@ Hayride has `private` or `reserved` imports that are not intended for `public` u
 
 They include:
 
-- `hayride:silo/threads@0.0.59` and `hayride:silo/process@0.0.59`: Silo implements basic parallelism and concurrency primitives for the Hayride platform. It provides a way to run Morphs in parallel and manage their execution. This is not intended for public use and is reserved for the Hayride platform. More holistic Async support is being discussed by the WebAssembly community and may replace this in the future.
+- `hayride:silo/threads@0.0.60` and `hayride:silo/process@0.0.60`: Silo implements basic parallelism and concurrency primitives for the Hayride platform. It provides a way to run Morphs in parallel and manage their execution. This is not intended for public use and is reserved for the Hayride platform. More holistic Async support is being discussed by the WebAssembly community and may replace this in the future.
 
 ### Public Imports
 
 The Server includes the following `public` imports:
+- `hayride:core/version@0.0.60`: A Hayride core interface which provides a function to check the latest version of Hayride releases.
 - `wasi:config/store@0.2.0-draft`: The WASI config store which provides an interface to include a component that exports a config store, which is implemented the Hayride cfg morph to provide access to the Hayride config.
 
 ### Public Exports
@@ -51,7 +55,7 @@ The Server includes the following `public` imports:
 The Server includes the following `public` exports:
 
 - `wasi:http/incoming-handler@0.2.0`: The WASI http incoming-handler which provides an entry point for handling http requests.
-- `hayride:http/config@0.0.59`: A hayride specific config interface to allow server implementations to expose their own server configuration through a `get` function. See below for an example of what this wit definition looks like.
+- `hayride:http/config@0.0.60`: A hayride specific config interface to allow server implementations to expose their own server configuration through a `get` function. See below for an example of what this wit definition looks like.
 
 ```wit
 interface types {

--- a/docs/reference/api/hayride.md
+++ b/docs/reference/api/hayride.md
@@ -163,3 +163,35 @@ If successful, the server will respond with the updated session status.
   }
 }
 ```
+
+> **GET /v1/version**
+
+Submits a request to get the current configured version of Hayride.
+
+**Response**
+
+If successful, the server will respond with a version string.
+
+```JSON
+{
+  "data": {
+    "version": "v0.0.2-alpha"
+  }
+}
+```
+
+> **GET /v1/version/latest**
+
+Submits a request to get the latest released version of Hayride.
+
+**Response**
+
+If successful, the server will respond with a version string.
+
+```JSON
+{
+  "data": {
+    "version": "v0.0.2-alpha"
+  }
+}
+```


### PR DESCRIPTION
# Description

- Updated wit definitions to latest versions.
- Updated Server wit and docs to reference core/version interface
- Add Hayride API documentation for `/v1/version/` and `/v1/version/latest`
- Updated installation wording to include Windows and Linux